### PR TITLE
Generate arealStats for ensemble members #21

### DIFF
--- a/KAPy/helpers.py
+++ b/KAPy/helpers.py
@@ -1,5 +1,6 @@
 import os
 import KAPy
+import glob
 
 def buildPath(cfg,thisDir, *p):
     '''
@@ -11,4 +12,12 @@ def buildPath(cfg,thisDir, *p):
         return(os.path.join(cfg['dirs']['outputDir'],*p))
     else:
         return(os.path.join(cfg['dirs']['outputDir'],cfg['dirs'][thisDir],*p))
-   
+
+def listFiles(cfg,thisDir,pattern='*'):
+    '''
+    Get files by path
+    
+    Lists the files present in a folder, where the folder is identified
+    by the directory key named in the configuration file
+    '''
+    return glob.glob(KAPy.buildPath(cfg,thisDir,pattern))

--- a/Snakefile
+++ b/Snakefile
@@ -201,20 +201,38 @@ for thisDS in datasetList:
         
 
 #Areal statistics------------------
+#Areal statistics can be calculated for both the enssemble statistics and the
+#individual ensemble members - these options can be turned on and off as required
+#via the configuration options. However, this situation also creates an ambiguity 
+#that needs to be resolved explicitly - see ruleorder directive
+arealstatsStems=KAPy.listFiles(config,"ensstats")
+if config['arealstats']['calcForMembers']:
+    arealstatsStems+=KAPy.listFiles(config,"indicators")
+    
 rule arealstats:
     input:
-        expand(KAPy.buildPath(config,'arealstats','i{ind}_{dataset}.csv'),
-               ind=indList,
-               dataset=datasetList)
+        expand(KAPy.buildPath(config,'arealstats','{fnamestem}.csv'),
+               fnamestem=[os.path.splitext(os.path.basename(x))[0] 
+                               for x in arealstatsStems])
 
-rule arealstats_singular:
+rule arealstats_from_ensstats:
     output:
-        KAPy.buildPath(config,'arealstats','i{ind}_{ds}.csv')
+        KAPy.buildPath(config,'arealstats','{stem}.csv')
     input:
-        KAPy.buildPath(config,'ensstats','i{ind}_ensstat_{ds}.nc')
+        KAPy.buildPath(config,'ensstats','{stem}.nc')
     run:
         KAPy.generateArealstats(config,input,output)
-    
+
+rule arealstats_from_ens_members:
+    output:
+        KAPy.buildPath(config,'arealstats','{stem}.csv')
+    input:
+        KAPy.buildPath(config,'indicators','{stem}.nc')
+    run:
+        KAPy.generateArealstats(config,input,output)
+
+#ruleorder: arealstats_from_ensstats > arealstats_from_ens_members
+
 
 # Outputs ---------------------------------
 # Notebooks, amongst other things

--- a/configs/defaults.yaml
+++ b/configs/defaults.yaml
@@ -5,6 +5,8 @@
 #here, so this file can also be used as an exhaustive list of configuration options
 #Keys are sorted in alphabetical order at the first level at least
 
+arealstats:
+    calcForMembers: False
 dirs:
     outputDir: 'outputs'
     search: '0.search'

--- a/notebooks/Indicator_plots.Rmd
+++ b/notebooks/Indicator_plots.Rmd
@@ -35,9 +35,9 @@ spPaths <-
   separate_wider_regex(fname,c("^i",ind=".+","_ensstat_",scenario=".+",".nc") ) 
 arealPaths <- 
   tibble(arealPath=dir(here(cfg$dirs$outputDir,cfg$dirs$arealstats),
-                    pattern=".csv$",full.names = TRUE),
+                    pattern="^.*ensstat.*.csv$",full.names = TRUE),
          fname=basename(arealPath)) %>% 
-  separate_wider_regex(fname,c("^i",ind=".+","_",scenario=".+",".csv") ) 
+  separate_wider_regex(fname,c("^i",ind=".+","_ensstat_",scenario=".+",".csv") ) 
 allPaths <-
   full_join(spPaths,arealPaths,by=c("ind","scenario")) %>% 
   nest(srcs=-ind)


### PR DESCRIPTION
Add functionality where arealStats can be calculated for individual ensemble members, in addition to the full ensemble statistics. Functionality is turned on/off using a config.yaml switch