### PR TITLE
Remove recursive updating of config

### DIFF
--- a/KAPy/configs.py
+++ b/KAPy/configs.py
@@ -19,19 +19,13 @@ def loadConfig(configfile='config.yaml',useDefaults=True,defaultFile='configs/de
         #Load defaults
         with open(defaultFile, 'r') as f:
             dft=yaml.safe_load(f)
-        #Recursive update function - thanks to ChatGPT
-        def recursive_update_dict(d, update_dict):
-            for key, value in d.items():
-                if isinstance(value, dict) and key in update_dict:
-                    # If the value is another dictionary and the key exists in the update_dict,
-                    # recursively update it with the corresponding update_dict entry.
-                    recursive_update_dict(value, update_dict[key])
-                elif key in update_dict:
-                    # If the key exists in the update_dict, 
-                    # update the value in the original dictionary.
-                    d[key] = update_dict[key]                   
-            return(d)
-        rtn=recursive_update_dict(dft,cfg)
+        #Previously we have done a partial update of the defaults, using a 
+        #recursive function that digs down below the top level. This doesn't
+        #work very well unfortunately, particularly when you want to exclude 
+        #elements. Here we use a simple top-level replacement instead
+        rtn=dft
+        for key,values in cfg.items():
+            rtn[key]=values
         return(rtn)
     else:
         return(cfg)

--- a/KAPy/indicators.py
+++ b/KAPy/indicators.py
@@ -6,7 +6,8 @@ import numpy as np
 import sys
 
 #config=KAPy.loadConfig()
-#inFile=['./workDir/2.primVars/tas_CORDEX_rcp26_tas_AFR-22_MOHC-HadGEM2-ES_r1i1p1_GERICS-REMO2015_v1_mon.nc']
+#inFile=['./workDir/2.primVars/tas_CORDEX_rcp45_AFR-22_MPI-M-MPI-ESM-LR_r1i1p1_GERICS-REMO2015_v1_mon.nc']
+#thisInd=config['indicators'][101]
 
 def calculateIndicators(config,inFile,outFile,thisInd):
     

--- a/configs/tutorial/config.yaml
+++ b/configs/tutorial/config.yaml
@@ -33,4 +33,14 @@ indicators:
         season: 'Annual'   #Use key name for seasons. Use 'All' for all defined seasons.
         statistic: 'mean'
         time_binning: "periods" #Choose between periods, year, month
-
+scenarios:  #A combination of CMIP experiments that are basis for analysis
+    rcp26:
+        id: 26
+        shortname: 'rcp26'
+        description: 'Low emissions scenario (RCP2.6)'
+        experiments: ['historical','rcp26']
+    rcp85:
+        id: 85
+        shortname: 'rcp85'
+        description: 'High emissions scenario (RCP8.5)'
+        experiments: ['historical','rcp85']


### PR DESCRIPTION
Previously, `config.yaml` would update the default configurations recursively, burrowing down into subtags. This change removes that functionality, and makes replacement at the top levels. This is both more transparent, but also allows for options to be removed, which was not previously possible