### PR TITLE
Dealing with ERA5 in ensembles.py

### DIFF
--- a/docs/tutorials/Tutorial02.md
+++ b/docs/tutorials/Tutorial02.md
@@ -56,7 +56,7 @@ snakemake --cores 1
 
 10. We can illustrate this point further by damaging the state of the pipeline. Let's remove an individual file in the middle of the pipeline.
 ```
-rm results/6.ensstats/101_CORDEX_rcp26_ensstats.nc 
+rm results/5.ensstats/101_CORDEX_rcp26_ensstats.nc 
 ```
 11. What's going to happen when we run snakemake now? Try and form a hypothesis.
 

--- a/workflow/KAPy/ensembles.py
+++ b/workflow/KAPy/ensembles.py
@@ -67,7 +67,8 @@ def generateArealstats(config,inFile,outFile):
     #Perform masking
     #TODO
     
-    #Average spatially
+    #Average spatially;  ============> LINE 71 BELOW THROWS AN ERROR WHEN SNAKEMAKE IS DEALING WITH ERA5 DATA BECAUSE ERA5 HAS "latitude" AND "longitude" iINSTEAD OF "rlat" and "rlon".
+    #I went around this problem by just renaming the lat and lon coordinates to rlat and rlon outside KAPy. I guess maybe we can incoperate a line code "eraData = eraData.rename({'latitude': 'rlat', 'longitude': 'rlon'})"
     spMean=thisDat.indicator.mean(dim=["rlon","rlat"])
     
     #Save files pandas

--- a/workflow/KAPy/ensembles.py
+++ b/workflow/KAPy/ensembles.py
@@ -67,7 +67,7 @@ def generateArealstats(config,inFile,outFile):
     #Perform masking
     #TODO
     
-    #Average spatially;
+    #Average spatially
     spMean=thisDat.indicator.mean(dim=["rlon","rlat"])
     
     #Save files pandas

--- a/workflow/KAPy/ensembles.py
+++ b/workflow/KAPy/ensembles.py
@@ -67,8 +67,7 @@ def generateArealstats(config,inFile,outFile):
     #Perform masking
     #TODO
     
-    #Average spatially;  ============> LINE 71 BELOW THROWS AN ERROR WHEN SNAKEMAKE IS DEALING WITH ERA5 DATA BECAUSE ERA5 HAS "latitude" AND "longitude" iINSTEAD OF "rlat" and "rlon".
-    #I went around this problem by just renaming the lat and lon coordinates to rlat and rlon outside KAPy. I guess maybe we can incoperate a line code "eraData = eraData.rename({'latitude': 'rlat', 'longitude': 'rlon'})"
+    #Average spatially;
     spMean=thisDat.indicator.mean(dim=["rlon","rlat"])
     
     #Save files pandas


### PR DESCRIPTION
*Line 71 throws an error when SNAKEMAKEis dealing with ERA5 data because ERA5 has "latitude" and "longitude" instead of "rlat" and "rlon".

*I went around this problem by unconventionaly just renaming the lat and lon coordinates to rlat and rlon outside KAPy.  I guess maybe we can incooperate a line code "eraData = eraData.rename({'latitude': 'rlat', 'longitude': 'rlon'})" inside the code. @markpayneatwork , how can we sort this?